### PR TITLE
fixed runtime error for loading the pages and translated getting started page

### DIFF
--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -18,109 +18,109 @@ redirect_from:
   - "docs/environments.html"
 ---
 
-ഈ പേജിന്റെ ഒരു ചുരുക്കവിവരണമാണ് React ഡോക്യുമെന്റേഷനുകളും അനുബന്ധ വിഭവങ്ങളും.
+React ഡോക്യൂമെന്റേഷന്റെയും അനുബന്ധ സ്രോതസ്സുകളുടെയും ഒരു പൊതുവായ അവലോകനമാണ് ഈ പേജ്.
 
-**React** യൂസർ ഇൻറർഫേസുകൾ നിർമ്മിക്കുന്നതിനുള്ള ഒരു ജാവാസ്ക്രിപ്റ്റ് ഗ്രന്ഥശാലയാണ്. React എന്തിനു എന്തു പഠിക്കണം [our homepage](/) or [in the tutorial](/tutorial/tutorial.html).
+**React** എന്നത് യൂസർ ഇന്റർഫേസുകൾ നിർമ്മിക്കുന്നതിനുള്ള ഒരു JavaScript ലൈബ്രറിയാണ്. React എന്തെല്ലാമാണെന്നത് [ഞങ്ങളുടെ ഹോം പേജിൽ](/) നിന്നും [ഈ ട്യൂട്ടോറിയലിൽ](/tutorial/tutorial.html) നിന്നും പഠിച്ചെടുക്കാം.
 
 ---
 
-- [ശ്രമിക്കുക React](#try-react)
-- [React പടിക്കുക](#learn-react)
-- [അറിന്നു കൊണ്ട് ഇരിക്കുക](#staying-informed)
-- [Versioned ഡോക്യുമെന്റേഷൻ](#versioned-documentation)
-- [എന്തോ വിട്ട് പൊയൊ?](#something-missing)
+- [React പരിശോധിക്കാം](#try-react)
+- [React പഠിക്കാം](#learn-react)
+- [അറിവ് മെച്ചപ്പെടുത്താം](#staying-informed)
+- [ഡോക്യൂമെന്റേഷൻ പതിപ്പുകൾ](#versioned-documentation)
+- [എന്തെങ്കിലും വിട്ട് പോയോ?](#something-missing)
 
-## ശ്രമിക്കുക React {#try-react}
+## React പരിശോധിക്കാം {#try-react}
 
-React has been designed from the start for gradual adoption, and **you can use as little or as much React as you need.** Whether you want to get a taste of React, add some interactivity to a simple HTML page, or start a complex React-powered app, the links in this section will help you get started.
+ക്രമേണയുള്ള നവീകരണങ്ങൾ മുന്നിൽ കണ്ട് കൊണ്ടാണ് React തുടക്കം മുതൽ ഡിസൈൻ ചെയ്തിരിക്കുന്നത്, **വളരെ കുറഞ്ഞ തോതിലോ അല്ലെങ്കിൽ ആവശ്യമുള്ള അത്രയും അളവിലോ** നിങ്ങൾക്ക് React ഉപയോഗിക്കാം. നിങ്ങളുടെ ആവശ്യം എന്തുമായിക്കൊള്ളട്ടെ, React ഒന്ന് രുചിച്ചു നോക്കുവാനോ, ഒരു ലളിതമായ HTML പേജിൽ ഉപഭോക്താക്കളെ സമ്പർക്കം ചെയ്യുക്കുന്നതിനാവശ്യമായ കൂട്ടിച്ചേർക്കലുകൾക്കോ അല്ലെങ്കിൽ വളരെയധികം സങ്കീർണ്ണമായ ഒരു React app നിർമ്മിക്കുന്നതോ ആണെങ്കിൽ പോലും ഈ ഭാഗത്തിൽ ഉള്ള ലിങ്കുകൾ നിങ്ങളെ തുടക്കം കുറിക്കാൻ സഹായിക്കും.
 
-### ഓൺലൈന് േപ്ലയ്ഗറയണ്ട് {#online-playgrounds}
+### ഓൺലൈൻ പ്ലേ ഗ്രൗണ്ട് {#online-playgrounds}
 
-If you're interested in playing around with React, you can use an online code playground. Try a Hello World template on [CodePen](codepen://hello-world), [CodeSandbox](https://codesandbox.io/s/new), or [Glitch](https://glitch.com/edit/#!/remix/starter-react-template).
+React-ൽ കളിച്ചു നോക്കുവാൻ താല്പര്യമുണ്ടെങ്കിൽ നിങ്ങൾക്ക് ഓൺലൈൻ കോഡ് പ്ലേ ഗ്രൗണ്ട് ഉപയോഗിക്കാവുന്നതാണ്. [CodePen](codepen://hello-world), [CodeSandbox](https://codesandbox.io/s/new), അല്ലെങ്കിൽ [Glitch](https://glitch.com/edit/#!/remix/starter-react-template) എന്നീ പ്ലേ ഗ്രൗണ്ടുകളിൽ ഒരു Hello World template പരിശോധിച്ച് നോക്കാം..
 
-If you prefer to use your own text editor, you can also [download this HTML file](https://raw.githubusercontent.com/reactjs/reactjs.org/master/static/html/single-file-example.html), edit it, and open it from the local filesystem in your browser. It does a slow runtime code transformation, so we'd only recommend using this for simple demos.
+നിങ്ങളുടെ സ്വന്തം text editor ഉപയോഗിക്കാൻ ആണ് താല്പര്യമെങ്കിൽ നിങ്ങൾക്ക് ഈ [HTML ഫയൽ ഡൌൺലോഡ്](https://raw.githubusercontent.com/reactjs/reactjs.org/master/static/html/single-file-example.html) ചെയ്യാം, അത് എഡിറ്റ് ചെയ്ത ശേഷം ഫയൽ സിസ്റ്റം വഴി നിങ്ങളുടെ ബ്രൗസറിൽ തുറന്നു നോക്കാം. വേഗത കുറഞ്ഞ കോഡ് രൂപാന്തരം ആയതിനാൽ ലളിതമായ ഡെമോക്ക് മാത്രമേ ഞങ്ങൾ ഇത് ശുപാർശ ചെയ്യുന്നുള്ളൂ.
 
-### React വെബ്സിടിൽ ചെര്ക്കുക {#add-react-to-a-website}
+### ഒരു വെബ്‌സൈറ്റിലോട്ട് React ചേർക്കാം {#add-react-to-a-website}
 
-You can [add React to an HTML page in one minute](/docs/add-react-to-a-website.html). You can then either gradually expand its presence, or keep it contained to a few dynamic widgets.
+നിങ്ങൾക്ക് [ഒരു മിനിറ്റിൽ HTML പേജിൽ React ചേർക്കാൻ](/docs/add-react-to-a-website.html) സാധിക്കും. ഒന്നുകിൽ നിങ്ങൾക്ക് അതിന്റെ സാന്നിദ്ധ്യം ക്രമേണ വർധിപ്പിച്ചെടുക്കാം, അല്ലെങ്കിൽ ചില dynamic widget-ൽ മാത്രമായി ഒതുക്കാം.
 
-### Create a New React App {#create-a-new-react-app}
+### ഒരു പുതിയ React App ഉണ്ടാക്കാം {#create-a-new-react-app}
 
-When starting a React project, a [simple HTML page with script tags](/docs/add-react-to-a-website.html) might still be the best option. It only takes a minute to set up!
+ഒരു React പ്രൊജക്റ്റ് തുടങ്ങുമ്പോൾ [script tag ഉപയോഗിച്ച ലളിതമായ HTML പേജ്](/docs/add-react-to-a-website.html) ഇപ്പോഴും ഒരു മികച്ച രീതിയാണ്. അത്തരത്തിൽ ഉണ്ടാക്കിയെടുക്കാൻ വളരെ കുറഞ്ഞ സമയം മതി!
 
-As your application grows, you might want to consider a more integrated setup. There are [several JavaScript toolchains](/docs/create-a-new-react-app.html) we recommend for larger applications. Each of them can work with little to no configuration and lets you take full advantage of the rich React ecosystem.
+നിങ്ങളുടെ application വളരുന്നതിനനുസരിച്ചു കൂടുതൽ സമന്വയിപ്പിക്കാൻ സാധിക്കുന്ന ഒരു രീതി പരിഗണിക്കേണ്ടി വരും. വലിയ application-കൾക്കായി ഞങ്ങൾ [നിരവധി JavaScript toolchains](/docs/create-a-new-react-app.html) ശുപാർശ ചെയ്യുന്നുണ്ട്. അവയിൽ ഓരോന്നും ചെറിയതോ അല്ലെങ്കിൽ configuration ഇല്ലാതേയോ പ്രവർത്തിക്കുക വഴി സമ്പന്നമായ React ecosystem നൽകുന്ന ഗുണങ്ങൾ പ്രയോജനപ്പെടുത്താൻ സഹായിക്കുന്നു.
 
-## Learn React {#learn-react}
+## React പഠിക്കാം {#learn-react}
 
-People come to React from different backgrounds and with different learning styles. Whether you prefer a more theoretical or a practical approach, we hope you'll find this section helpful.
+വിവിധ പശ്ചാത്തലങ്ങളിൽ നിന്നും വ്യത്യസ്തമായ പഠനരീതികൾ ഉള്ളവർ React-ലേക്ക് വരുന്നുണ്ട്. നിങ്ങൾ പരിഗണിക്കുന്നത് വായനാരൂപമായാലും പ്രാക്ടിക്കൽ സമീപനമായാലും ഈ ഭാഗം സഹായകരമായിരിക്കും എന്ന് ഞങ്ങൾ പ്രതീക്ഷിക്കുന്നു.
 
-* If you prefer to **learn by doing**, start with our [practical tutorial](/tutorial/tutorial.html).
-* If you prefer to **learn concepts step by step**, start with our [guide to main concepts](/docs/hello-world.html).
+* നിങ്ങൾക്ക് **ചെയ്തു കൊണ്ട് പഠിക്കാൻ** ആണ് താല്പര്യമെങ്കിൽ ഞങ്ങളുടെ [പ്രാക്ടിക്കൽ ട്യൂട്ടോറിയൽ](/tutorial/tutorial.html) ആരംഭിക്കാം.
+* നിങ്ങൾക്ക് **പടിപടിയായി ആശയം ഉൾക്കൊണ്ട് പഠിക്കാൻ** ആണ് താല്പര്യമെങ്കിൽ ഞങ്ങളുടെ [പ്രധാന ആശയങ്ങളിലേക്കുള്ള ഗൈഡ്](/docs/hello-world.html) ആരംഭിക്കാം.
 
-Like any unfamiliar technology, React does have a learning curve. With practice and some patience, you *will* get the hang of it.
+ഏതൊരു അപരിചിതമായ സാങ്കേതികവിദ്യയും പോലെ React പഠനവും തുടക്കത്തിൽ അല്പം സാവധാനം ആയിരിക്കും. പരിശീലനവും കുറച്ചു ക്ഷമയും വഴി നിങ്ങൾക്ക് *ഉറപ്പായും* അത് മറികടക്കാം.
 
-### First Examples {#first-examples}
+### ആദ്യ ഉദാഹരണം {#first-examples}
 
-The [React homepage](/) contains a few small React examples with a live editor. Even if you don't know anything about React yet, try changing their code and see how it affects the result.
+[React ഹോം പേജിൽ](/) ലൈവ് എഡിറ്ററിൽ ചില React ഉദാഹരണങ്ങൾ നൽകിയിട്ടുണ്ട്. നിങ്ങൾക്ക് React നെ കുറിച്ച് ഒന്നും അറില്ലെങ്കിൽ പോലും ആ കോഡിൽ വരുത്തുന്ന മാറ്റങ്ങൾ എങ്ങനെ റിസൾട്ടിനെ ബാധിക്കുന്നു എന്ന് പരിശോധിച്ചു നോക്കാം.
 
-### React for Beginners {#react-for-beginners}
+### തുടക്കക്കാർക്ക് വേണ്ടിയുള്ള React {#react-for-beginners}
 
-If you feel that the React documentation goes at a faster pace than you're comfortable with, check out [this overview of React by Tania Rascia](https://www.taniarascia.com/getting-started-with-react/). It introduces the most important React concepts in a detailed, beginner-friendly way. Once you're done, give the documentation another try!
+നിങ്ങൾക്ക് ആശ്വാസകരമായ രീതിയിലധികം വേഗതയിൽ ആണ് ഈ ഡോക്യൂമെന്റേഷൻ പോകുന്നത് എന്ന് തോന്നുന്നുണ്ടെങ്കിൽ [Tania Rascia യുടെ React ന്റെ പൊതുവായ അവലോകനം](https://www.taniarascia.com/getting-started-with-react/) വായിച്ചു നോക്കാവുന്നതാണ്.  തുടക്കക്കാർക്ക് അനുയോജ്യമായ രീതിയിൽ React-ന്റെ പരമപ്രധാനമായ ആശയങ്ങൾ അതിൽ വിശദമായ അവതരിപ്പിക്കുന്നുണ്ട്. അത് പൂർത്തിയാക്കിയ ശേഷം ഇത് വീണ്ടും നോക്കാം.
 
-### React for Designers {#react-for-designers}
+### Designers-നു വേണ്ടിയുള്ള React {#react-for-designers}
 
-If you're coming from a design background, [these resources](https://reactfordesigners.com/) are a great place to get started.
+നിങ്ങൾ ഒരു design പശ്ചാത്തലത്തിൽ നിന്നാണ് വരുന്നതെങ്കിൽ, [ഈ സ്രോതസ്സുകൾ](https://reactfordesigners.com/) ഉപകാരപ്രദമായിരിക്കും.
 
-### JavaScript Resources {#javascript-resources}
+### JavaScript സ്രോതസ്സുകൾ {#javascript-resources}
 
-The React documentation assumes some familiarity with programming in the JavaScript language. You don't have to be an expert, but it's harder to learn both React and JavaScript at the same time.
+JavaScript programming language-ൽ ഉള്ള പരിചയം ഈ React ഡോക്യൂമെന്റേഷൻ പ്രതീക്ഷിക്കുന്നുണ്ട്. നിങ്ങൾ അതിൽ അഗ്രഗണ്യൻ ആകണമെന്നില്ല. എന്നാൽ React-നൊപ്പം JavaScript പഠിക്കുക എന്നത് അല്പം ബുദ്ധിമുട്ടായിരിക്കും.
 
-We recommend going through [this JavaScript overview](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript) to check your knowledge level. It will take you between 30 minutes and an hour but you will feel more confident learning React.
+നിങ്ങളുടെ അറിവ് പരിശോധിക്കുന്നതിനായി ഈ [JavaScript overview](https://developer.mozilla.org/en-US/docs/Web/JavaScript/A_re-introduction_to_JavaScript) ഉപയോഗിച്ച് നോക്കാൻ ഞങ്ങൾ ശുപാർശ ചെയ്യുന്നു. അര മണിക്കൂർ മുതൽ ഒരു മണിക്കൂർ വരെ സമയം എടുക്കുമെങ്കിലും React പഠിക്കുന്നതിൽ നിങ്ങൾക്ക് കൂടുതൽ ആത്മവിശ്വാസം നേടാനാകും.
 
->Tip
+>നുറുങ്ങു വിദ്യ
 >
->Whenever you get confused by something in JavaScript, [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript) and [javascript.info](https://javascript.info/) are great websites to check. There are also [community support forums](/community/support.html) where you can ask for help.
+>JavaScript-ൽ എന്തെങ്കിലും ആശയക്കുഴപ്പം ഉണ്ടാകുമ്പോൾ [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript), [javascript.info](https://javascript.info/) എന്നീ വെബ്സൈറ്റുകൾ പരിശോധിക്കാവുന്നതാണ്. [കമ്മ്യൂണിറ്റി സപ്പോർട് ഫോറത്തിലും](/community/support.html) നിങ്ങൾക് സഹായം അഭ്യർത്ഥിക്കാവുന്നതാണ്.
 
-### Practical Tutorial {#practical-tutorial}
+### പ്രാക്ടിക്കൽ ട്യൂട്ടോറിയൽ {#practical-tutorial}
 
-If you prefer to **learn by doing,** check out our [practical tutorial](/tutorial/tutorial.html). In this tutorial, we build a tic-tac-toe game in React. You might be tempted to skip it because you're not building games -- but give it a chance. The techniques you'll learn in the tutorial are fundamental to building *any* React apps, and mastering it will give you a much deeper understanding.
+നിങ്ങൾക്ക് **ചെയ്തു കൊണ്ട് പഠിക്കാൻ** ആണ് താല്പര്യമെങ്കിൽ ഞങ്ങളുടെ [പ്രാക്ടിക്കൽ ട്യൂട്ടോറിയൽ](/tutorial/tutorial.html) പരിശോധിച്ച് നോക്കാം. ഈ ട്യൂട്ടോറിയലിൽ നമ്മൾ ഒരു tic-tac-toe ഗെയിം ആണ് ഉണ്ടാക്കിയെടുക്കുന്നത്. ഗെയിമുകൾ ഉണ്ടാക്കുക എന്നത് ഒരു ആത്യന്തിക ലക്ഷ്യമല്ലാതിത്താൽ ഇത് ഒഴിവാക്കാൻ നിങ്ങൾക്ക് തോന്നിയേക്കാം - എങ്കിലും ഒന്ന് ശ്രമിച്ചു നോക്കുന്നത് നല്ലതായിരിക്കും. ഈ ട്യൂട്ടോറിയൽ വഴി നിങ്ങൾ പഠിച്ചെടുക്കുന്ന കാര്യങ്ങൾ *ഏതൊരു* React apps ഉണ്ടാക്കുന്നതിനും അടിസ്ഥാനപരമായി ആവശ്യമുള്ളതാണ്, അതിൽ മേൽക്കൈ നേടുക എന്നത് ആഴത്തിൽ കാര്യങ്ങൾ മനസ്സിലാക്കിയെടുക്കാൻ സഹായിക്കും.
 
-### Step-by-Step Guide {#step-by-step-guide}
+### പടിപടിയായുള്ള ഗൈഡ് {#step-by-step-guide}
 
-If you prefer to **learn concepts step by step,** our [guide to main concepts](/docs/hello-world.html) is the best place to start. Every next chapter in it builds on the knowledge introduced in the previous chapters so you won't miss anything as you go along.
+നിങ്ങൾക്ക് **പടിപടിയായി ആശയം ഉൾക്കൊണ്ട് പഠിക്കാൻ** ആണ് താല്പര്യമെങ്കിൽ ഞങ്ങളുടെ [പ്രധാന ആശയങ്ങളിലേക്കുള്ള ഗൈഡ്](/docs/hello-world.html) ആണ് ഏറ്റവും മികച്ച പ്രാരംഭം. ഓരോ അദ്ധ്യായവും മുൻപത്തെ അദ്ധ്യായങ്ങളിൽ ഉണ്ടാക്കിയെടുത്ത അറിവ് വിപുലപ്പെടുത്തുന്ന രീതിയിൽ ആയതിനാൽ നിങ്ങൾ മുന്നോട്ട് പോകുന്തോറും ഒന്നും നഷ്ടപ്പെടാതെ തുടരാനാകും.
 
-### Thinking in React {#thinking-in-react}
+### React-ൽ ചിന്തിക്കൽ {#thinking-in-react}
 
-Many React users credit reading [Thinking in React](/docs/thinking-in-react.html) as the moment React finally "clicked" for them. It's probably the oldest React walkthrough but it's still just as relevant.
+ഒട്ടുമിക്ക React ഉപഭോക്താക്കളും React അവർക്ക് "ക്ലിക്ക് ആയ ശേഷം" ആണ് [React-ൽ ചിന്തിക്കൽ](/docs/thinking-in-react.html) വായിച്ചു തുടങ്ങുന്നത്. അല്പം പഴയ വിവരണമാണെങ്കിൽ പോലും ഇന്നും അതിനു വളരെയധികം പ്രസക്തിയുണ്ട്.
 
-### Recommended Courses {#recommended-courses}
+### ശുപാർശ ചെയ്യുന്ന കോഴ്‌സുകൾ {#recommended-courses}
 
-Sometimes people find third-party books and video courses more helpful than the official documentation. We maintain [a list of commonly recommended resources](/community/courses.html), some of which are free.
+ചില സമയങ്ങളിൽ ഒഫീഷ്യൽ ഡോക്യൂമെന്റേഷനേക്കാൾ മൂന്നാമതൊരാൾ നൽകുന്ന പുസ്തകങ്ങളോ വിഡിയോ കോഴ്സുകളോ ആയിരിക്കും ആളുകൾക്ക് കൂടുതൽ സഹായകരം. [ശുപാർശ ചെയ്യുന്ന സ്രോതസ്സുകളുടെ ഒരു ലിസ്റ്റ്](/community/courses.html) ഞങ്ങൾ സൂക്ഷിക്കുന്നുണ്ട്, അവയിൽ പലതും സൗജന്യമാണ്.
 
-### Advanced Concepts {#advanced-concepts}
+### വിപുലമായ ആശയങ്ങൾ {#advanced-concepts}
 
-Once you're comfortable with the [main concepts](/docs/hello-world.html) and played with React a little bit, you might be interested in more advanced topics. This section will introduce you to the powerful, but less commonly used React features like [context](/docs/context.html) and [refs](/docs/refs-and-the-dom.html).
+React ഉപയോഗിച്ച് അല്പം കളിച്ച ശേഷം [പ്രധാന ആശയങ്ങൾ](/docs/hello-world.html)  നിങ്ങൾക്ക് എളുപ്പമായി തോന്നുമ്പോൾ, കൂടുതൽ വിപുലമായ ആശയങ്ങളിൽ നിങ്ങൾക്ക് താല്പര്യം തോന്നിയേക്കാം. ഈ ഭാഗം കൂടുതൽ ശക്തമായതും എന്നാൽ വളരെ കുറച്ചു മാത്രം ഉപയോഗിക്കുന്നതുമായ [context](/docs/context.html), [refs](/docs/refs-and-the-dom.html) പോലെയുള്ള React സവിശേഷതകൾ നിങ്ങളെ പരിചയപ്പടുത്തും.
 
-### API Reference {#api-reference}
+### API പ്രമാണം {#api-reference}
 
-This documentation section is useful when you want to learn more details about a particular React API. For example, [`React.Component` API reference](/docs/react-component.html) can provide you with details on how `setState()` works, and what different lifecycle methods are useful for.
+നിങ്ങൾക്ക് ഒരു പ്രത്യേക React API-യുടെ കൂടുതൽ വിവരങ്ങൾ പഠിക്കണം എന്നുണ്ടെങ്കിൽ ഈ ഡോക്യൂമെന്റേഷൻ സെക്ഷൻ ഉപകാരപ്രദമായിരിക്കും. ഉദാഹരണത്തിന് [`React.Component` API പ്രമാണ](/docs/react-component.html)ത്തിൽ `setState()` എങ്ങനെയാണ് പ്രവർത്തിക്കുന്നത്, ഏതെല്ലാം lifecycle method-കൾ ആണ് ഉപകാരപ്രദമായിട്ടുള്ളത് എന്നിവയെ കുറിച്ചുള്ള വിശദ വിവരങ്ങൾ ലഭ്യമാണ്.
 
-### Glossary and FAQ {#glossary-and-faq}
+### ശബ്ദസംഗ്രഹവും ഇടക്കിടെയുള്ള ചോദ്യങ്ങളും {#glossary-and-faq}
 
-The [glossary](/docs/glossary.html) contains an overview of the most common terms you'll see in the React documentation. There is also a FAQ section dedicated to short questions and answers about common topics, including [making AJAX requests](/docs/faq-ajax.html), [component state](/docs/faq-state.html), and [file structure](/docs/faq-structure.html).
+React ഡോക്യൂമെന്റേഷനിൽ സാധാരണയായി ഉപയോഗിക്കുന്ന വാക്കുകളുടെ അവലോകനം [ശബ്ദസംഗ്രഹത്തിൽ](/docs/glossary.html) ലഭ്യമാണ്. [AJAX request ഉണ്ടാക്കുക](/docs/faq-ajax.html),  [component state](/docs/faq-state.html), [file structure](/docs/faq-structure.html) പോലുള്ള പൊതുവായ വിഷയങ്ങളിൽ സ്ഥിരമായി കണ്ടുവരുന്ന ചെറു ചോദ്യങ്ങൾക്കും അവയുടെ ഉത്തരങ്ങൾക്കും വേണ്ടി മാത്രമായി FAQ വിഭാഗവും ഉൾപ്പെടുത്തിയിട്ടുണ്ട്.
 
-## Staying Informed {#staying-informed}
+## അറിവ് മെച്ചപ്പെടുത്താം {#staying-informed}
 
-The [React blog](/blog/) is the official source for the updates from the React team. Anything important, including release notes or deprecation notices, will be posted there first.
+React ടീം പുറത്തു വിടുന്ന പുതിയ വിവരങ്ങൾക്ക് വേണ്ടിയുള്ള ഔദ്യോഗിക സ്രോതസ്സാണ് [React ബ്ലോഗ്](/blog/). പുതിയ പ്രസിദ്ധീകരണങ്ങളും ഒഴിവാക്കലുകളും അടക്കം പ്രാധാന്യമർഹിക്കുന്ന എന്തും ആദ്യം വരുന്നത് അവിടെ ആയിരിക്കും.
 
-You can also follow the [@reactjs account](https://twitter.com/reactjs) on Twitter, but you won't miss anything essential if you only read the blog.
+നിങ്ങൾക്ക് ട്വിറ്ററിലും [@reactjs അക്കൗണ്ട്](https://twitter.com/reactjs) ഫോളോ ചെയ്യാം, നിങ്ങൾ ബ്ലോഗ് മാത്രം വായിക്കുന്ന വ്യക്തിയാണെങ്കിലും അത്യന്താപേക്ഷിതമായ കൂട്ടിച്ചേർക്കലുകൾ ഒന്നും തന്നെ നിങ്ങൾക്ക് നഷ്ടപ്പെടില്ല.
 
-Not every React release deserves its own blog post, but you can find a detailed changelog for every release in the [`CHANGELOG.md` file in the React repository](https://github.com/facebook/react/blob/master/CHANGELOG.md), as well as on the [Releases](https://github.com/facebook/react/releases) page.
+എല്ലാ React റിലീസിനും ബ്ലോഗ് പ്രസിദ്ധീകരണം ഉണ്ടായിക്കൊള്ളണം എന്നില്ല, എന്നാൽ ഓരോ റിലീസിന്റേയും വിശദമായ വിവരണം [React റെപ്പോസിറ്ററിയിലെ `CHANGELOG.md` ഫയലി](https://github.com/facebook/react/blob/master/CHANGELOG.md)ലും [റിലീസസ്](https://github.com/facebook/react/releases) പേജിലും ഉണ്ടായിരിക്കുന്നതാണ്. 
 
-## Versioned Documentation {#versioned-documentation}
+## ഡോക്യൂമെന്റേഷൻ പതിപ്പുകൾ {#versioned-documentation}
 
-This documentation always reflects the latest stable version of React. Since React 16, you can find older versions of the documentation on a [separate page](/versions). Note that documentation for past versions is snapshotted at the time of the release, and isn't being continuously updated.
+ഈ ഡോക്യുമെന്റ് എപ്പോഴും React-ന്റെ ഏറ്റവും പുതിയ സ്ഥിരതയുള്ള പതിപ്പിനെ പ്രതിനിധീകരിക്കുന്നതായിരിക്കും. React 16 ഇറങ്ങിയത് മുതൽ, പഴയ പതിപ്പുകളുടെ ഡോക്യൂമെന്റേഷൻ ഇതിൽ നിന്നും [വിഭിന്നമായ പേജിൽ](/versions) കണ്ടെത്താൻ സാധിക്കും. പഴയ പതിപ്പുകളുടെ ഡോക്യൂമെന്റേഷൻ അത് ഇറക്കിയ സമയത്തുള്ള അതേ രൂപാന്തരത്തിൽ ആണ് സൂക്ഷിച്ചിട്ടുള്ളത്, അവ കൃത്യമായി നവീകരിച്ചിട്ടില്ല എന്ന് ഓർത്തിരിക്കുക.
 
-## Something Missing? {#something-missing}
+## എന്തെങ്കിലും വിട്ട് പോയോ? {#something-missing}
 
-If something is missing in the documentation or if you found some part confusing, please [file an issue for the documentation repository](https://github.com/reactjs/reactjs.org/issues/new) with your suggestions for improvement, or tweet at the [@reactjs account](https://twitter.com/reactjs). We love hearing from you!
+ഈ ഡോക്യൂമെന്റേഷനിൽ എന്തെങ്കിലും കണ്ടെത്താൻ ആകാതെ വരികയോ അല്ലെങ്കിൽ ഏതെങ്കിലും ഭാഗം ആശയക്കുഴപ്പം സൃഷ്ടിക്കുകയോ ചെയ്യുന്നുണ്ടെങ്കിൽ ദയവായി നിങ്ങളുടെ നിർദ്ദേശങ്ങളോടൊപ്പം [ഡോക്യൂമെന്റേഷന് വേണ്ടി ഒരു പ്രശ്നം സൃഷ്ടിക്കുക](https://github.com/reactjs/reactjs.org/issues/new),യോ ഞങ്ങൾക്ക് ട്വീറ്റ് ആയി  [@reactjs അക്കൗണ്ടി](https://twitter.com/reactjs)ലേക്ക് അയക്കുകയോ ചെയ്യുക.  നിങ്ങളിൽ നിന്ന് കേൾക്കാൻ ഞങ്ങൾ ഇഷ്ടപ്പെടുന്നു.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -51,7 +51,6 @@ class Home extends Component {
       <Layout location={location}>
         <TitleAndMetaTags
           title="React &ndash; യൂസര്‍ ഇന്റര്‍ഫേസുകള്‍ നിര്‍മ്മിക്കുവാനായി ഒരു ‍ജാവാസ്ക്രിപ്റ്റ് ലൈബ്രറി"
-          ogUrl={createOgUrl('index.html')}
           canonicalUrl={createCanonicalUrl('/')}
         />
         <div css={{width: '100%'}}>


### PR DESCRIPTION
yarn dev was throwing Uncaught ReferenceError: createOgUrl is not defined. Compared it with the original react repo and found the obsolete line and removed it.

Properly translated getting started page.

Would like to translate more if this PR is reviewed and merged.